### PR TITLE
Upgrade to Lab 3.x.x.  Also bumped versions of Hoek and Hapi.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test:
 	@node node_modules/lab/bin/lab
 test-cov: 
-	@node node_modules/lab/bin/lab -r threshold -t 100
+	@node node_modules/lab/bin/lab -t 100
 test-cov-html:
 	@node node_modules/lab/bin/lab -r html -o coverage.html
 

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   },
   "dependencies": {
     "heapdump": "0.2.x",
-    "hoek": "1.x.x"
+    "hoek": "2.x.x"
   },
   "peerDependencies": {
     "hapi": ">=2.x.x"
   },
   "devDependencies": {
-    "hapi": "3.x.x",
-    "lab": "1.x.x"
+    "hapi": "4.x.x",
+    "lab": "3.x.x"
   },
   "scripts": {
     "test": "make test-cov"


### PR DESCRIPTION
After moving to Lab 3.x.x, the following line is the only one missing coverage:

```
var settings = Hoek.applyToDefaults(internals.defaults, options || {});
```

However, because poop checks if it's been initialized during registration, I can't simply add another test to exercise `options`.  I had a few ideas on how to work around this, but I'd be more interested in how @hueniverse would like it implemented.
