### PR TITLE
Add settings for processDump

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,9 @@ var Hoek = require('hoek');
 var internals = {
     initialized: false,
     defaults: {
-        logPath: Path.join(__dirname, '..', 'poop.log')
+        logPath: Path.join(__dirname, '..', 'poop.log'),
+        processDump: true,
+        processDumpDir: Path.join(__dirname, '..' )
     }
 };
 
@@ -28,7 +30,9 @@ exports.register = function (plugin, options, next) {
 
     process.once('uncaughtException', function (err) {
 
-        HeapDump.writeSnapshot();
+        if( settings.processDump === true ){
+            HeapDump.writeSnapshot( settings.processDumpDir );
+        }
 
         var log = Fs.createWriteStream(settings.logPath);
         var formattedErr = {
@@ -46,7 +50,9 @@ exports.register = function (plugin, options, next) {
 
     process.on('SIGUSR1', function () {
 
-        HeapDump.writeSnapshot();
+        if( settings.processDump === true ){
+            HeapDump.writeSnapshot( settings.processDumpDir );
+        }
     });
 
     return next();


### PR DESCRIPTION
This Pull Request solves following point
- I don't always want to generate the process report so I would like to manage it via a setting
- I wanna specify a location where the dump file should be placed as I'm doing for the log file
