### PR TITLE
Update table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Lead Maintainer: [Colin Ihrig](https://github.com/cjihrig)
 - [Overview](#overview)
 - [Example](#example)
 - [Settings](#settings)
+    - [`heapdumpFolder`](#heapdumpfolder)
     - [`logPath`](#logpath)
     - [`writeStreamOptions`](#writestreamoptions)
 


### PR DESCRIPTION
The "heapdumpFolder" link was missing from the table of contents
